### PR TITLE
chore: add temporary selection debug logs

### DIFF
--- a/apps/client/src/hooks/useObjectSelection.ts
+++ b/apps/client/src/hooks/useObjectSelection.ts
@@ -159,7 +159,14 @@ export function useObjectSelection({
         if (mode === "replace") {
           sendMessage({ t: "deselect-object", uid });
         } else {
-          sendMessage({ t: "select-multiple", uid, objectIds: normalizedIncoming, mode });
+          const payload: ClientMessage = {
+            t: "select-multiple",
+            uid,
+            objectIds: normalizedIncoming,
+            mode,
+          };
+          console.debug("[Selection] Sending select-multiple (empty nextIds)", payload);
+          sendMessage(payload);
         }
         return;
       }
@@ -168,7 +175,14 @@ export function useObjectSelection({
       if (mode === "replace" && nextIds.length === 1) {
         sendMessage({ t: "select-object", uid, objectId: nextIds[0]! });
       } else {
-        sendMessage({ t: "select-multiple", uid, objectIds: normalizedIncoming, mode });
+        const payload: ClientMessage = {
+          t: "select-multiple",
+          uid,
+          objectIds: normalizedIncoming,
+          mode,
+        };
+        console.debug("[Selection] Sending select-multiple", payload);
+        sendMessage(payload);
       }
     },
     [activeEntry, sendMessage, uid],

--- a/apps/client/src/ui/App.tsx
+++ b/apps/client/src/ui/App.tsx
@@ -635,6 +635,10 @@ function AuthenticatedApp({
         clearSelection();
         return;
       }
+      console.debug(
+        "[Selection][App] handleObjectSelectionBatch received ids:",
+        objectIds,
+      );
       selectMultiple(objectIds, "replace");
     },
     [clearSelection, selectMultiple],


### PR DESCRIPTION
## Summary
- add temporary debug logging in the App marquee selection handler to capture object IDs
- log select-multiple payloads in the object selection hook before sending websocket messages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f43efc8c14832a9aa9996dbd3d3fc9