### PR TITLE
Document pnpm client build command for packaging

### DIFF
--- a/CLOUDFLARE_PAGES_DEPLOYMENT.md
+++ b/CLOUDFLARE_PAGES_DEPLOYMENT.md
@@ -33,12 +33,12 @@ Click **Show advanced** and configure:
 - **Build command**:
 
   ```bash
-  corepack enable && pnpm install --frozen-lockfile && pnpm build
+  corepack enable && pnpm install --frozen-lockfile && pnpm --filter herobyte-client build
   ```
 
   - `corepack enable` ensures pnpm is available in the build environment
   - `--frozen-lockfile` ensures exact dependency versions from pnpm-lock.yaml
-  - `pnpm build` builds the client (which also builds the shared package)
+  - `pnpm --filter herobyte-client build` compiles the client (and shared package) exactly the way CI/CD does before packaging `apps/client/dist`
 
 - **Build output directory**: `dist`
   - Vite outputs the built files to the `dist` directory

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -75,13 +75,14 @@ NODE_ENV=production
 | -------------------------- | ---------------------------------------------- |
 | **Project name**           | `herobyte` (or your choice)                    |
 | **Production branch**      | `main`                                         |
-| **Build command**          | `pnpm install --frozen-lockfile && pnpm build` |
+| **Build command**          | `pnpm install --frozen-lockfile && pnpm --filter herobyte-client build` |
 | **Build output directory** | `dist`                                         |
 
 **Important - Advanced Settings:**
 
 - Click **Build settings** → **Show advanced**
 - Set **Root directory (advanced)** to: `apps/client`
+- Cloudflare runs `pnpm --filter herobyte-client build` in CI/CD so the compiled `apps/client/dist` bundle exists before packaging
 
 ### C. Environment Variables
 

--- a/PRODUCTION_CHECKLIST.md
+++ b/PRODUCTION_CHECKLIST.md
@@ -32,7 +32,7 @@ Use this checklist before deploying to production to catch issues early.
 ### 3. Build Verification
 
 - [ ] Server builds successfully: `pnpm build:server`
-- [ ] Client builds successfully: `pnpm build:client`
+- [ ] Client builds successfully: `pnpm --filter herobyte-client build` (CI/CD runs this exact command before packaging `apps/client/dist`)
 - [ ] No TypeScript errors
 - [ ] No build warnings (or all are known/acceptable)
 


### PR DESCRIPTION
## Summary
- record the exact `pnpm --filter herobyte-client build` command in deployment checklists and docs to show CI/CD builds the client before packaging `apps/client`
- clarify the Cloudflare Pages build instructions so the pipeline compiles the client bundle prior to asset packaging

## Testing
- pnpm --filter herobyte-client build

------
https://chatgpt.com/codex/tasks/task_e_68f43efe3868832ab327d9f07907803e