### PR TITLE
Silence Vitest console noise in CI

### DIFF
--- a/apps/client/vitest.config.ts
+++ b/apps/client/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
 
+const isCI = Boolean(process.env.CI && process.env.CI !== "false" && process.env.CI !== "0");
+const shouldSilenceConsoleOutput = process.env.VITEST_SILENT === "true" || isCI;
+
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
   test: {
@@ -9,6 +12,7 @@ export default defineConfig({
     setupFiles: "./vitest.setup.ts",
     globals: true,
     pool: "forks",
+    silent: shouldSilenceConsoleOutput,
     coverage: {
       provider: "istanbul",
       reporter: ["text", "json", "lcov"],

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -1,11 +1,15 @@
 import { defineConfig } from "vitest/config";
 
+const isCI = Boolean(process.env.CI && process.env.CI !== "false" && process.env.CI !== "0");
+const shouldSilenceConsoleOutput = process.env.VITEST_SILENT === "true" || isCI;
+
 export default defineConfig({
   test: {
     environment: "node",
     globals: true,
     include: ["src/**/*.test.ts"],
     setupFiles: [],
+    silent: shouldSilenceConsoleOutput,
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "json"],

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,11 +1,15 @@
 import { defineConfig } from "vitest/config";
 
+const isCI = Boolean(process.env.CI && process.env.CI !== "false" && process.env.CI !== "0");
+const shouldSilenceConsoleOutput = process.env.VITEST_SILENT === "true" || isCI;
+
 export default defineConfig({
   test: {
     environment: "node",
     globals: true,
     include: ["src/**/*.test.ts", "**/*.test.ts"],
     reporters: [["default", { summary: false }]],
+    silent: shouldSilenceConsoleOutput,
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "json"],


### PR DESCRIPTION
## Summary
- add a shared CI-aware helper flag to each Vitest config
- enable Vitest's `silent` mode whenever we are running in CI (or when `VITEST_SILENT=true`) to prevent extremely noisy logs from passing tests

## Testing
- `CI=1 pnpm --filter vtt-server test -- src/domains/__tests__/mapService.test.ts`
- `CI=1 pnpm --filter @shared test`
- `CI=1 pnpm --filter herobyte-client test -- src/features/initiative/components/__tests__/InitiativeModal.test.tsx`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a1ff2dd74832a937e6e93523732a1)