### PR TITLE
Speed up client coverage runner

### DIFF
--- a/apps/client/scripts/run-vitest-coverage.mjs
+++ b/apps/client/scripts/run-vitest-coverage.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -22,6 +22,12 @@ const defaultChunkSize = process.env.CI ? ciDefaultChunkSize : localDefaultChunk
 const chunkSizeInput = Number(process.env.CLIENT_COVERAGE_CHUNK_SIZE ?? defaultChunkSize);
 const chunkSize = Number.isFinite(chunkSizeInput) && chunkSizeInput > 0 ? Math.floor(chunkSizeInput) : defaultChunkSize;
 
+const ciDefaultConcurrency = Math.max(2, Math.floor(cpuCount / 2));
+const localDefaultConcurrency = Math.max(2, cpuCount - 2);
+const defaultConcurrency = process.env.CI ? ciDefaultConcurrency : localDefaultConcurrency;
+const concurrencyInput = Number(process.env.CLIENT_COVERAGE_CONCURRENCY ?? defaultConcurrency);
+const requestedConcurrency = Number.isFinite(concurrencyInput) && concurrencyInput > 0 ? Math.floor(concurrencyInput) : defaultConcurrency;
+
 const globPatterns = ["src/**/*.{test,spec}.{ts,tsx}", "src/**/*.{test,spec}.?(c|m)[jt]s?(x)"];
 const ignorePatterns = ["**/node_modules/**", "**/dist/**"];
 
@@ -42,10 +48,36 @@ console.log(
   `[coverage] Discovered ${allTests.length} test files. Using batch size ${chunkSize} (override with CLIENT_COVERAGE_CHUNK_SIZE).`,
 );
 
+const includePatternInput = process.env.CLIENT_COVERAGE_INCLUDE?.trim();
+let filteredTests = allTests;
+
+if (includePatternInput) {
+  let matcher;
+  try {
+    matcher = new RegExp(includePatternInput);
+  } catch (error) {
+    console.error(`[coverage] Invalid CLIENT_COVERAGE_INCLUDE regex: ${error.message}`);
+    process.exit(1);
+  }
+
+  filteredTests = allTests.filter((file) => matcher.test(file.replace(/\\/g, "/")));
+
+  if (filteredTests.length === 0) {
+    console.error(
+      `[coverage] CLIENT_COVERAGE_INCLUDE=${includePatternInput} did not match any files out of ${allTests.length} tests. Aborting.`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `[coverage] CLIENT_COVERAGE_INCLUDE matched ${filteredTests.length}/${allTests.length} test files. Running filtered set only.`,
+  );
+}
+
 const toPosix = (p) => p.replace(/\\/g, "/");
-const heavyFiles = allTests.filter((file) => toPosix(file).includes("/characterization/"));
+const heavyFiles = filteredTests.filter((file) => toPosix(file).includes("/characterization/"));
 const heavySet = new Set(heavyFiles);
-const normalFiles = allTests.filter((file) => !heavySet.has(file));
+const normalFiles = filteredTests.filter((file) => !heavySet.has(file));
 
 const chunk = (items, size) => {
   const batches = [];
@@ -67,32 +99,88 @@ if (batches.length === 0) {
 
 const coverageMap = createCoverageMap({});
 
-for (const [index, files] of batches.entries()) {
+const concurrency = Math.min(batches.length, requestedConcurrency);
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "client-coverage-"));
+
+console.log(`[coverage] Running ${concurrency} batch${concurrency === 1 ? "" : "es"} in parallel (override with CLIENT_COVERAGE_CONCURRENCY).`);
+
+const baseCoverageArgs = [
+  "vitest",
+  "run",
+  "--coverage.enabled",
+  "true",
+  "--coverage.reporter",
+  "json",
+  "--no-file-parallelism",
+  "--reporter",
+  "dot",
+];
+
+const runBatch = async (index, files) => {
   const relativeFiles = files.map((file) => path.relative(projectRoot, file));
   console.log(`\n[coverage] Batch ${index + 1}/${batches.length} (${files.length} files) ➜ ${relativeFiles.join(", ")}`);
-  fs.rmSync(coverageDir, { recursive: true, force: true });
 
-  const result = spawnSync("pnpm", ["vitest", "run", "--coverage", "--no-file-parallelism", "--reporter=dot", ...files], {
-    cwd: projectRoot,
-    stdio: "inherit",
-    env: process.env,
+  const outputDir = path.join(tempRoot, `batch-${String(index + 1).padStart(4, "0")}`);
+  fs.rmSync(outputDir, { recursive: true, force: true });
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  const args = [...baseCoverageArgs, "--coverage.reportsDirectory", outputDir, ...files];
+
+  await new Promise((resolve, reject) => {
+    const child = spawn("pnpm", args, {
+      cwd: projectRoot,
+      stdio: "inherit",
+      env: process.env,
+    });
+
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      const reason = typeof code === "number" ? `exit code ${code}` : `signal ${signal}`;
+      reject(new Error(`[coverage] Vitest failed for batch ${index + 1} (${reason}).`));
+    });
   });
 
-  if (result.status !== 0) {
-    console.error(`[coverage] Vitest failed for batch ${index + 1}.`);
-    process.exit(result.status ?? 1);
-  }
-
-  const partialPath = path.join(coverageDir, "coverage-final.json");
+  const partialPath = path.join(outputDir, "coverage-final.json");
   if (!fs.existsSync(partialPath)) {
-    console.error(`[coverage] Missing coverage output after batch ${index + 1}.`);
-    process.exit(1);
+    throw new Error(`[coverage] Missing coverage output after batch ${index + 1}.`);
   }
 
   const partial = JSON.parse(fs.readFileSync(partialPath, "utf8"));
   coverageMap.merge(partial);
+
+  fs.rmSync(outputDir, { recursive: true, force: true });
+};
+
+let nextBatchIndex = 0;
+
+const scheduleNext = async () => {
+  const index = nextBatchIndex;
+  const files = batches[index];
+  nextBatchIndex += 1;
+  if (!files) {
+    return;
+  }
+  await runBatch(index, files);
+  await scheduleNext();
+};
+
+const workers = Array.from({ length: concurrency }, () => scheduleNext());
+
+try {
+  await Promise.all(workers);
+} catch (error) {
+  console.error(error.message ?? error);
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+  process.exit(1);
 }
 
+fs.rmSync(tempRoot, { recursive: true, force: true });
 fs.rmSync(coverageDir, { recursive: true, force: true });
 fs.mkdirSync(coverageDir, { recursive: true });
 

--- a/apps/client/vitest.config.ts
+++ b/apps/client/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
 
+const isCI = Boolean(process.env.CI && process.env.CI !== "false" && process.env.CI !== "0");
+const shouldSilenceConsoleOutput = process.env.VITEST_SILENT === "true" || isCI;
+
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
   test: {
@@ -9,6 +12,7 @@ export default defineConfig({
     setupFiles: "./vitest.setup.ts",
     globals: true,
     pool: "forks",
+    silent: shouldSilenceConsoleOutput,
     coverage: {
       provider: "istanbul",
       reporter: ["text", "json", "lcov"],

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -1,11 +1,15 @@
 import { defineConfig } from "vitest/config";
 
+const isCI = Boolean(process.env.CI && process.env.CI !== "false" && process.env.CI !== "0");
+const shouldSilenceConsoleOutput = process.env.VITEST_SILENT === "true" || isCI;
+
 export default defineConfig({
   test: {
     environment: "node",
     globals: true,
     include: ["src/**/*.test.ts"],
     setupFiles: [],
+    silent: shouldSilenceConsoleOutput,
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "json"],

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,11 +1,15 @@
 import { defineConfig } from "vitest/config";
 
+const isCI = Boolean(process.env.CI && process.env.CI !== "false" && process.env.CI !== "0");
+const shouldSilenceConsoleOutput = process.env.VITEST_SILENT === "true" || isCI;
+
 export default defineConfig({
   test: {
     environment: "node",
     globals: true,
     include: ["src/**/*.test.ts", "**/*.test.ts"],
     reporters: [["default", { summary: false }]],
+    silent: shouldSilenceConsoleOutput,
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "json"],


### PR DESCRIPTION
## Summary
- run multiple vitest coverage batches in parallel and merge their output from temporary directories so CI no longer grinds through them sequentially
- add an optional `CLIENT_COVERAGE_INCLUDE` regex filter to help developers focus coverage runs on a subset of test files when iterating locally

## Testing
- `CLIENT_COVERAGE_INCLUDE=SessionTab CLIENT_COVERAGE_CONCURRENCY=2 pnpm --filter herobyte-client test:coverage`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a1ff2dd74832a937e6e93523732a1)